### PR TITLE
Add config to include extension in filter_regex

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -7,7 +7,7 @@ Location
 The flake8-filename plug-in loads its configuration options from the same source as standard flake8 configuration.
 Flake8 supports storing its configuration in the following places:
 
-Your top-level user directory In your project in one of ``setup.cfg``, ``tox.ini``, or ``.flake8``.For more information
+Your top-level user directory. In your project in one of ``setup.cfg``, ``tox.ini``, or ``.flake8``. For more information
 on configuration locations see:
 
 Flake8_configuration_
@@ -23,8 +23,12 @@ You may configure up to 50 filename validators.
 +---------------------+----------------------------------------------+-------------------------------------------------+
 | filename_regex      + any valid regex that does not contain spaces | A regex to validate filtered Python filenames   |
 +---------------------+----------------------------------------------+-------------------------------------------------+
+| filter_with_ext     + A Boolean                                    | Whether to include the file extension when      |
+|                     +                                              | filtering files. Default is to strip extension. |
++---------------------+----------------------------------------------+-------------------------------------------------+
 
-**This plug-in will automatically strip the leading path and extension for the Python files under evaluation.**
+**This plug-in will automatically strip the leading path for the Python files under evaluation, and extension, unless
+`filter_with_ext` is set.**
 
 Examples:
 =========

--- a/flake8_filename/__init__.py
+++ b/flake8_filename/__init__.py
@@ -45,7 +45,7 @@ class FilenameChecker(object):
                 for single_line in filename_data:
                     a = [s.strip() for s in single_line.split('=')]
                     # whitelist the acceptable params
-                    if a[0] in ['filter_regex', 'filename_regex']:
+                    if a[0] in ['filter_regex', 'filename_regex', 'filter_with_ext']:
                         parsed_params[a[0]] = a[1]
                 d[filename_check] = parsed_params
         cls.filename_checks.update(d)

--- a/flake8_filename/rules.py
+++ b/flake8_filename/rules.py
@@ -35,7 +35,9 @@ def rule_n5xx(filename, rule_name, rule_conf, class_type):
     code = _generate_mark_code(rule_name)
     message = "N5{} filename failed regex validation '{}'".format(code, rule_conf['filename_regex'])
 
-    sanitized_filename = splitext(basename(filename))[0]    # Strip path and extension
+    sanitized_filename = basename(filename)  # Strip path
+    if not rule_conf.get("filter_with_ext"):
+        sanitized_filename = splitext(sanitized_filename)[0]    # Strip extension
 
     if re.match(rule_conf['filter_regex'], sanitized_filename):
         if not re.match(rule_conf['filename_regex'], sanitized_filename):


### PR DESCRIPTION
# Use case

I want to make sure *.rst filenames are lowercase in kebab case, for example:

* ❌ BadName.rst
* ❌ bad_name.rst
* ✅ good-name.rst

# Currently

However, with this config, `flake8 *.rst` returns nothing:

```ini
[flake8]
filename_check1 = filter_regex=.+\.rst$
                  filename_regex=^[a-z-]+\.rst$
```
```console
$ flake8 *.rst
$
```

That's because the extension (and path) are stripped before applying the filter regex.

# PR

This PR adds a `filter_with_ext` config so the extension is kept. For example:

```ini
[flake8]
filename_check1 = filter_regex=.+\.rst$
                  filename_regex=^[a-z-]+\.rst$
                  filter_with_ext=True
```
```console
$ flake8 *.rst
BadName.rst:0:1: N501 filename failed regex validation '^[a-z-]+\.rst$'
bad_name.rst:0:1: N501 filename failed regex validation '^[a-z-]+\.rst$'
$
```

